### PR TITLE
build(site): move site assembly from CI into build script

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,25 +37,6 @@ jobs:
       - name: Install and build
         run: pnpm install && pnpm build
 
-      - name: Copy llms.txt into site
-        run: cp llms.txt site/
-
-      - name: Copy examples into site
-        run: |
-          mkdir -p site/examples
-          cp examples/*.html site/examples/
-
-      - name: Copy dist assets into site/examples
-        run: |
-          cp dist/lys.css site/examples/
-          cp dist/lys.iife.js site/examples/
-
-      - name: Rewrite example asset paths
-        run: |
-          sed -i 's|/src/lys.css|lys.css|g' site/examples/*.html
-          sed -i 's|/src/lys.ts|lys.iife.js|g' site/examples/*.html
-          sed -i 's|type="module" src="lys.iife.js"|src="lys.iife.js"|g' site/examples/*.html
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 coverage/
 test-results/
 playwright-report/
+site/examples/
+site/llms.txt

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.0.x/schema.json",
 	"files": {
-		"includes": ["**", "!dist"]
+		"includes": ["**", "!dist", "!site/examples", "!site/llms.txt"]
 	},
 	"assist": {
 		"actions": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	],
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc --noEmit && vite build && node scripts/inject-skill.js",
+		"build": "tsc --noEmit && vite build && node scripts/inject-skill.js && node scripts/build-site.js",
 		"preview": "vite preview",
 		"lint": "biome check --write .",
 		"typecheck": "tsc --noEmit",

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -1,0 +1,38 @@
+/**
+ * Assembles the site/ directory for GitHub Pages deployment.
+ *
+ * Copies examples (with rewritten asset paths) and llms.txt into site/,
+ * alongside the dist assets they need. Run after `vite build`.
+ */
+
+import { cpSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(import.meta.url), "../..");
+const site = resolve(root, "site");
+const examplesOut = resolve(site, "examples");
+
+// 1. Copy llms.txt into site/
+cpSync(resolve(root, "llms.txt"), resolve(site, "llms.txt"));
+
+// 2. Copy dist assets into site/examples/
+mkdirSync(examplesOut, { recursive: true });
+cpSync(resolve(root, "dist/lys.css"), resolve(examplesOut, "lys.css"));
+cpSync(resolve(root, "dist/lys.iife.js"), resolve(examplesOut, "lys.iife.js"));
+
+// 3. Copy and rewrite example HTML files
+const examplesSrc = resolve(root, "examples");
+for (const file of readdirSync(examplesSrc)) {
+	if (!file.endsWith(".html")) continue;
+
+	let html = readFileSync(resolve(examplesSrc, file), "utf8");
+	html = html.replaceAll("/src/lys.css", "lys.css");
+	html = html.replaceAll("/src/lys.ts", "lys.iife.js");
+	html = html.replaceAll('type="module" src="lys.iife.js"', 'src="lys.iife.js"');
+	writeFileSync(resolve(examplesOut, file), html);
+}
+
+console.log(
+	`✓ Site assembled: llms.txt + ${readdirSync(examplesOut).length} files in site/examples/`,
+);


### PR DESCRIPTION
Replace inline shell steps in the Pages workflow with a Node build-site.js script that runs as part of `pnpm build`. Exclude generated site/ assets from Biome linting.