### PR TITLE
Publish under scoped name @11thdeg/lys

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@ Lys ships as:
 
 - **`lys.css`** — The structural stylesheet. Can be used standalone for CSS-only decks.
 - **`lys.ts` / `lys.js`** — The behavioral layer. Auto-initializes on `data-lys` containers.
-- **ESM module** — `import { Lys } from 'lys'`
+- **ESM module** — `import { Lys } from '@11thdeg/lys'`
 - **Script tag** — `<script src="lys.js"></script>` (auto-init via IIFE, exposes `window.Lys`)
 
 ### Single-File Inline Usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.2] — 2026-06-22
 
+### Changed
+
+- Published under the scoped npm name `@11thdeg/lys` (the unscoped `lys` is owned by an unrelated package). Install with `npm install @11thdeg/lys`; CDN URLs use `unpkg.com/@11thdeg/lys`. No prior version was published to npm, so there is no migration.
+
 ### Fixed
 
 - Aspect-ratio conformity (#45): slides now honor `--lys-aspect-ratio` on every viewport instead of silently adopting the viewport's own ratio. Slides are sized to fit inside the viewport at the configured ratio (contain-fit — both axes bounded, smaller governs, centered with `--lys-backdrop` in the letterbox/pillarbox margins). Previously a `100vh` height pin forced the viewport ratio on mobile and non-16:9 desktops. Applies to both default scroll-snap and stacked (fade/direct) modes.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -23,7 +23,7 @@
 pnpm init
 ```
 
-Set `"name": "lys"`, `"type": "module"` in `package.json`.
+Set `"name": "@11thdeg/lys"`, `"type": "module"` in `package.json`.
 
 ### 2. Install dev dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ⚜ Lys
 
-[![npm version](https://img.shields.io/npm/v/lys)](https://www.npmjs.com/package/lys)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/lys?label=CSS%20%2B%20JS)](https://bundlephobia.com/package/lys)
-[![license](https://img.shields.io/npm/l/lys)](./LICENSE)
+[![npm version](https://img.shields.io/npm/v/@11thdeg/lys)](https://www.npmjs.com/package/@11thdeg/lys)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/@11thdeg/lys?label=CSS%20%2B%20JS)](https://bundlephobia.com/package/@11thdeg/lys)
+[![license](https://img.shields.io/npm/l/@11thdeg/lys)](./LICENSE)
 
 **A structural slide engine for the age of generated content.**
 
@@ -23,7 +23,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Deck</title>
-  <link rel="stylesheet" href="https://unpkg.com/lys/dist/lys.css">
+  <link rel="stylesheet" href="https://unpkg.com/@11thdeg/lys/dist/lys.css">
 </head>
 <body>
   <div data-lys>
@@ -36,7 +36,7 @@
       <p>Navigate with arrow keys, swipe, or click.</p>
     </article>
   </div>
-  <script src="https://unpkg.com/lys/dist/lys.iife.js"></script>
+  <script src="https://unpkg.com/@11thdeg/lys/dist/lys.iife.js"></script>
 </body>
 </html>
 ```
@@ -44,8 +44,8 @@
 ## CDN usage
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/lys/dist/lys.css">
-<script src="https://unpkg.com/lys/dist/lys.iife.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@11thdeg/lys/dist/lys.css">
+<script src="https://unpkg.com/@11thdeg/lys/dist/lys.iife.js"></script>
 ```
 
 No setup code needed — Lys auto-initializes on `[data-lys]` containers.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "lys",
+	"name": "@11thdeg/lys",
 	"version": "1.0.2",
 	"type": "module",
 	"description": "A structural CSS+TS slide engine for LLM-generated presentations",
@@ -16,6 +16,9 @@
 	"files": [
 		"dist"
 	],
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc --noEmit && vite build && tsc --emitDeclarationOnly --outDir dist && node scripts/inject-skill.js && node scripts/build-site.js",

--- a/specs/readme-and-pages.spec.md
+++ b/specs/readme-and-pages.spec.md
@@ -22,7 +22,7 @@ A single Markdown file at the project root. Sections in order:
 3. **Live demo link** — Points to the GitHub Pages site.
 4. **"What it does"** — 3 bullets max: structural slides, zero-dependency, LLM-first.
 5. **Minimal example** — The 4-line deck from `examples/minimal.html` (the `<div data-lys>` + `<article>` pattern). Copy-paste ready.
-6. **CDN usage** — `<script>` and `<link>` tags using `unpkg.com/lys`.
+6. **CDN usage** — `<script>` and `<link>` tags using `unpkg.com/@11thdeg/lys`.
 7. **Token customization** — A `--lys-*` override snippet showing 2-3 tokens.
 8. **"For LLMs"** — Points to `llms.txt` (raw URL on GitHub) and `skill/SKILL.md`. Explains that LLMs should read `llms.txt` for the full API reference.
 9. **Links** — Pages site, `llms.txt`, `examples/`, `ARCHITECTURE.md`.
@@ -117,7 +117,7 @@ No changes to `src/`, `specs/` (other than this spec), `tests/`, or `dist/`.
 
 1. `README.md` exists and contains all 10 sections listed in the Architecture.
 2. `README.md` minimal example is valid HTML that works with Lys.
-3. `README.md` CDN URLs use `unpkg.com/lys` (the npm package name).
+3. `README.md` CDN URLs use `unpkg.com/@11thdeg/lys` (the npm package name).
 4. `README.md` links to the Pages site, `llms.txt`, examples, and ARCHITECTURE.md — all links resolve.
 5. `README.md` contains no install-from-source instructions in the body.
 6. `site/index.html` exists and is a valid HTML5 document (not a Lys deck).


### PR DESCRIPTION
## Fix the npm publish blocker

The `v1.0.0` and `v1.0.2` publish runs both failed with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/lys
```

The unscoped name **`lys`** is owned by an unrelated npm package, so the account can't publish to it (npm returns 404 for unowned names). Build, tests, and tarball all succeed — only the publish step is rejected.

## Change

- Rename the package to **`@11thdeg/lys`** + add `publishConfig.access: public`.
- Update README badges + `unpkg` CDN URLs, the ESM import example (`import { Lys } from '@11thdeg/lys'`), and the living docs (PROJECT.md, readme-and-pages spec).
- CHANGELOG `[1.0.2]` gains a `### Changed` note documenting the scoped name.

No version reached npm under the old name, so there is **no consumer migration**.

## After merge

Re-point the `v1.0.2` tag to the merged commit (force) and push → re-triggers the publish workflow, which will publish `@11thdeg/lys@1.0.2`. (Per maintainer decision: reuse 1.0.2 rather than cut a new patch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)