### PR TITLE
ci(publish): Node 24 for npm OIDC handshake (#50)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Trusted publishing requires Node >= 22.14.0 (and npm >= 11.5.1).
-          node-version: 22
+          # Node 24: trusted publishing needs npm >= 11.5.1 for the OIDC
+          # handshake. Node 22 bundles npm 10, whose handshake fails silently —
+          # the registry then treats the publish as anonymous and returns a
+          # misleading 404 on PUT. pnpm delegates to the system npm, so this
+          # version is what matters. (Stay on pnpm 10.x; pnpm 11 has its own
+          # OIDC regression, pnpm#11513.)
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
Follow-up to #55. Node 22 bundles npm 10, whose OIDC handshake fails (registry treats the publish as anonymous → misleading E404). Node 24 ships npm ≥ 11.5.1 and publishes cleanly via the existing trusted-publisher config. Unblocks the v1.1.1 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)