### PR TITLE
ci(publish): publish-only workflow (#57)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Publish-only: main is already pristine (lefthook pre-commit + PR flow),
+    # so this path never re-tests — it builds and publishes. Timeout guards
+    # against a hung step (a stuck Playwright install once burned 6h here).
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,15 +44,6 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: Run unit tests
-        run: pnpm test
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
-
-      - name: Run e2e tests
-        run: pnpm test:e2e
 
       # No NODE_AUTH_TOKEN: pnpm fetches an OIDC token via the id-token
       # permission above, which takes precedence over a static token.


### PR DESCRIPTION
Strip unit/e2e/Playwright-install from the release path — main is pristine via lefthook + PR flow, so Actions just builds and publishes. Adds a 15-min job timeout. Unblocks the v1.1.1 publish (the prior run hung 6h on the Playwright install). Part of #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)